### PR TITLE
fix: 修复title内容过长的展示问题

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,17 @@
 const app = getApp();
-const { statusBarHeight, system } = wx.getSystemInfoSync();
+const { statusBarHeight, system, windowWidth } = wx.getSystemInfoSync();
 const isIOS = /^ios/i.test(system);
+
+function calcMaxWidth(windowWidth, isIOS) {
+  const left = isIOS ? 7 : 10;
+  const capsuleWidth = 43 * 2 + 1;
+  const padding = isIOS ? 0 : 5;
+  const total = (left + capsuleWidth + padding * 2) * 2;
+
+  // `- 10` 是为了两边留出一点空白
+  const maxWidth = windowWidth - total - 10;
+  return maxWidth;
+}
 
 Component({
   options: {
@@ -98,6 +109,7 @@ Component({
     justOnePage: true,
     barHeight: +statusBarHeight,
     refresh: true,
+    maxWidth: calcMaxWidth(windowWidth, isIOS)
   },
   lifetimes: {
     attached() {

--- a/src/index.wxml
+++ b/src/index.wxml
@@ -14,7 +14,7 @@
       </cover-view>
     </cover-view>
     <cover-view class="slot"><slot name="action"></slot></cover-view>
-    <cover-view class="nav-title {{textStyle === 'light' ? 'light' : ''}}">{{title}}</cover-view>
+    <cover-view class="nav-title {{textStyle === 'light' ? 'light' : ''}}" style="max-width: {{maxWidth}}px;">{{title}}</cover-view>
   </cover-view>
 </cover-view>
 <cover-view wx:else class="_wrap" style="background: {{bgColor}};">
@@ -33,7 +33,7 @@
       </cover-view>
     </cover-view>
     <cover-view class="slot"><slot name="action"></slot></cover-view>
-    <cover-view class="nav-title {{textStyle === 'light' ? 'light' : ''}}">{{title}}</cover-view>
+    <cover-view class="nav-title {{textStyle === 'light' ? 'light' : ''}}" style="max-width: {{maxWidth}}px;">{{title}}</cover-view>
   </cover-view>
 </cover-view>
 <view style="padding-top: {{isIOS ? (barHeight + 44) : (barHeight + 48)}}px; {{autoHeight ? '' : 'height: 100%;'}}">

--- a/src/index.wxss
+++ b/src/index.wxss
@@ -108,6 +108,10 @@
 }
 
 .nav-title {
+  max-width: 150px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
   margin: auto;
   text-align: center;
   font-weight: 700;

--- a/tools/demo/pages/demo/index.js
+++ b/tools/demo/pages/demo/index.js
@@ -1,6 +1,6 @@
 Page({
   data: {
-    title: 'DEMO',
+    title: '这里有一个超长超长超长的title啊哈啊哈啊哈啊哈啊哈啊哈啊哈',
     showHome: true,
     hideBack: false,
     bgColor: '#df3348',


### PR DESCRIPTION
添加 `max-width`, 过长内容溢出省略